### PR TITLE
Add missing header for GCC 13

### DIFF
--- a/include/swoole_proxy.h
+++ b/include/swoole_proxy.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 #define SW_SOCKS5_VERSION_CODE 0x05
 


### PR DESCRIPTION
Without this header:

```
libtool: compile:  g++ -DENABLE_PHP_SWOOLE -I. -I/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS -DPHP_ATOM_INC -I/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/include -I/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/main -I/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS -I/usr/include/php -I/usr/include/php/main -I/usr/include/php/TSRM -I/usr/include/php/Zend -I/usr/include/php/ext -I/usr/include/php/ext/date/lib -I/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS -I/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/include -I/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/ext-src -I/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/thirdparty/hiredis -DHAVE_CONFIG_H -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Wall -Wno-unused-function -Wno-deprecated -Wno-deprecated-declarations -std=c++11 -c /builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/src/protocol/websocket.cc  -fPIC -DPIC -o src/protocol/.libs/websocket.o
In file included from /builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/src/protocol/socks5.cc:20:
/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/include/swoole_proxy.h:43:5: error: 'uint8_t' does not name a type
   43 |     uint8_t state;
      |     ^~~~~~~
/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/include/swoole_proxy.h:20:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   19 | #include <string>
  +++ |+#include <cstdint>
   20 | 
/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/include/swoole_proxy.h:44:5: error: 'uint8_t' does not name a type
   44 |     uint8_t dont_handshake;
      |     ^~~~~~~
/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/include/swoole_proxy.h:44:5: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/include/swoole_proxy.h:59:5: error: 'uint8_t' does not name a type
   59 |     uint8_t state;
      |     ^~~~~~~
/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/include/swoole_proxy.h:59:5: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/include/swoole_proxy.h:60:5: error: 'uint8_t' does not name a type
   60 |     uint8_t version;
      |     ^~~~~~~
/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/include/swoole_proxy.h:60:5: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/include/swoole_proxy.h:61:5: error: 'uint8_t' does not name a type
   61 |     uint8_t method;
      |     ^~~~~~~
/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/include/swoole_proxy.h:61:5: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/include/swoole_proxy.h:62:5: error: 'uint8_t' does not name a type
   62 |     uint8_t dns_tunnel;
      |     ^~~~~~~
/builddir/build/BUILD/php-pecl-openswoole22-22.0.0/NTS/include/swoole_proxy.h:62:5: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?

```