### PR TITLE
Update swoole_proxy.h

### DIFF
--- a/include/swoole_proxy.h
+++ b/include/swoole_proxy.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 #define SW_SOCKS5_VERSION_CODE 0x05
 


### PR DESCRIPTION
Add cstdint to includes, on some distributions like Arch Linux, the build procedure was failing to this error:

`error: ‘uint8_t’ does not name a type`

this PR insures that cstdint is included