### PR TITLE
fix php_url_encode_hash_ex call for 8.3

### DIFF
--- a/ext-src/php_swoole_private.h
+++ b/ext-src/php_swoole_private.h
@@ -1041,9 +1041,13 @@ static sw_inline char *php_swoole_http_build_query(zval *zdata, size_t *length, 
 #if PHP_VERSION_ID < 80000
     if (php_url_encode_hash_ex(
             HASH_OF(zdata), formstr, NULL, 0, NULL, 0, NULL, 0, NULL, NULL, (int) PHP_QUERY_RFC1738) == FAILURE) {
-#else
+#elif PHP_VERSION_ID < 80300
     if (HASH_OF(zdata)) {
         php_url_encode_hash_ex(HASH_OF(zdata), formstr, NULL, 0, NULL, 0, NULL, 0, NULL, NULL, (int) PHP_QUERY_RFC1738);
+    } else {
+#else
+    if (HASH_OF(zdata)) {
+        php_url_encode_hash_ex(HASH_OF(zdata), formstr, NULL, NULL, NULL, NULL, NULL, (int) PHP_QUERY_RFC1738);
     } else {
 #endif
         if (formstr->s) {


### PR DESCRIPTION
From UPGRADING.INTERNALS

```
   - The PHPAPI php_url_encode_hash_ex() function has had its signature change
     from:
     PHPAPI void php_url_encode_hash_ex(HashTable *ht, smart_str *formstr,
                                const char *num_prefix, size_t num_prefix_len,
                                const char *key_prefix, size_t key_prefix_len,
                                const char *key_suffix, size_t key_suffix_len,
                                zval *type, const char *arg_sep, int enc_type);
     to:
     PHPAPI void php_url_encode_hash_ex(HashTable *ht, smart_str *formstr,
                                const char *num_prefix, size_t num_prefix_len,
                                const zend_string *key_prefix,
                                zval *type, const zend_string *arg_sep, int enc_type);
     The change to use zend_string prevent the computation of the arg_sep
     length at each call. The key_suffix parameter was dropped as it was a
     constant value and depended on the key_prefix parameter to not be NULL.

```