### PR TITLE
fix cpu affinity check

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -129,6 +129,7 @@ AC_DEFUN([AC_SWOOLE_CPU_AFFINITY],
         #include <sys/cpuset.h>
         typedef cpuset_t cpu_set_t;
         #else
+        #define _GNU_SOURCE 1
         #include <sched.h>
         #endif
     ]], [[

--- a/config.m4
+++ b/config.m4
@@ -163,6 +163,7 @@ AC_DEFUN([AC_SWOOLE_HAVE_FUTEX],
 [
     AC_MSG_CHECKING([for futex])
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+        #define _GNU_SOURCE 1
         #include <linux/futex.h>
         #include <syscall.h>
         #include <unistd.h>


### PR DESCRIPTION
Same as https://github.com/swoole/swoole-src/pull/5624

Without _GNU_SOURCE, 

```
configure:13553: checking for cpu affinity
configure:13577: cc -c  -O2 -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64   -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer   conftest.c >&5
conftest.c: In function 'main':
conftest.c:50:9: error: implicit declaration of function 'CPU_ZERO' [-Wimplicit-function-declaration]
   50 |         CPU_ZERO(&cpu_set);
      |         ^~~~~~~~
configure:13577: $? = 1

```

Fix happen with recent GCC version 14.2 when implicit-function-declaration is now an error.